### PR TITLE
Expand validation errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 mod validation;
 
-use validation::{SpecVersion, Validate, ValidationError, ValidationErrors};
+use validation::{SpecVersion, Validate, ValidationBuilder, ValidationError, ValidationErrors};
 
 fn validate_timestamp(input: &str) -> Result<(), validation::ValidationError> {
     if input.contains("a") {
@@ -44,19 +44,11 @@ pub struct Tool {
 
 impl Validate for Tool {
     fn validate(&self, _version: validation::SpecVersion) -> Result<(), ValidationErrors> {
-        let mut result = std::result::Result::Ok(());
-
-        if let Some(vendor) = &self.vendor {
-            result = ValidationErrors::merge_field(result, "vendor", validate_vendor(vendor));
-        }
-
-        if let Some(name) = &self.name {
-            result = ValidationErrors::merge_field(result, "name", validate_string(name));
-        }
-
-        result = ValidationErrors::merge_enum(result, "kind", validate_toolkind(&self.kind));
-
-        result
+        ValidationBuilder::new()
+            .add_field("vendor", self.vendor.as_ref().map(|vendor| validate_vendor(&vendor)))
+            .add_field("name", self.name.as_ref().map(|name| validate_string(&name)))
+            .add_enum("kind", Some(validate_toolkind(&self.kind)))
+            .into()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 mod validation;
 
-use validation::{SpecVersion, Validate, ValidationBuilder, ValidationError, ValidationErrors};
+use validation::{SpecVersion, Validate, ValidationContext, ValidationError, ValidationErrors};
 
 fn validate_timestamp(input: &str) -> Result<(), validation::ValidationError> {
     if input.contains("a") {
@@ -44,7 +44,7 @@ pub struct Tool {
 
 impl Validate for Tool {
     fn validate(&self, _version: validation::SpecVersion) -> Result<(), ValidationErrors> {
-        ValidationBuilder::new()
+        ValidationContext::new()
             .add_field(
                 "vendor",
                 self.vendor.as_ref().map(|vendor| validate_vendor(&vendor)),
@@ -73,7 +73,7 @@ impl Validate for Metadata {
                 .collect::<Vec<_>>()
         });
 
-        let mut builder = ValidationBuilder::new().add_list("tools", children);
+        let mut builder = ValidationContext::new().add_list("tools", children);
 
         match version {
             SpecVersion::V1_4 => {
@@ -103,7 +103,7 @@ pub struct Bom {
 /// The implementation should be easy to digest
 impl Validate for Bom {
     fn validate(&self, version: validation::SpecVersion) -> Result<(), ValidationErrors> {
-        ValidationBuilder::new()
+        ValidationContext::new()
             .add_field("serial_number", self.serial_number.as_ref().map(|sn| validate_string(sn)))
             .add_struct("meta_data", self.meta_data.as_ref().map(|metadata| metadata.validate(version)))
             .into()

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -24,26 +24,50 @@ impl ValidationBuilder {
     }
 
     pub fn add_field(self, field_name: &str, error: Option<Result<(), ValidationError>>) -> Self {
-        let result = if let Some(error) = error {
-            error
+        if let Some(Err(error)) = error {
+            Self {
+                state: ValidationErrors::merge_field(self.state, field_name, Err(error)),
+            }
         } else {
-            std::result::Result::Ok(())
-        };
-
-        Self {
-            state: ValidationErrors::merge_field(self.state, field_name, result),
+            self
         }
     }
 
     pub fn add_enum(self, enum_name: &str, error: Option<Result<(), ValidationError>>) -> Self {
-        let result = if let Some(error) = error {
-            error
+        if let Some(Err(error)) = error {
+            Self {
+                state: ValidationErrors::merge_enum(self.state, enum_name, Err(error)),
+            }
         } else {
-            std::result::Result::Ok(())
-        };
+            self
+        }
+    }
 
-        Self {
-            state: ValidationErrors::merge_enum(self.state, enum_name, result),
+    pub fn add_list(
+        self,
+        field_name: &str,
+        children: Option<Vec<Result<(), ValidationErrors>>>,
+    ) -> Self {
+        if let Some(children) = children {
+            Self {
+                state: ValidationErrors::merge_list(self.state, field_name, children),
+            }
+        } else {
+            self
+        }
+    }
+
+    pub fn add_struct(
+        self,
+        struct_name: &str,
+        errors: Option<Result<(), ValidationErrors>>,
+    ) -> Self {
+        if let Some(Err(errors)) = errors {
+            Self {
+                state: ValidationErrors::merge_struct(self.state, struct_name, Err(errors)),
+            }
+        } else {
+            self
         }
     }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -9,14 +9,16 @@ pub enum SpecVersion {
     V1_5,
 }
 
+/// TODO: the `Result` is not meant to be used as shortcut or to raise errors, rather to collect all errors
+/// avoid using `?` operator
 pub type ValidationResult = Result<(), ValidationErrors>;
 
 #[derive(Debug)]
-pub struct ValidationBuilder {
+pub struct ValidationContext {
     state: ValidationResult,
 }
 
-impl ValidationBuilder {
+impl ValidationContext {
     pub fn new() -> Self {
         Self {
             state: std::result::Result::Ok(()),
@@ -76,16 +78,18 @@ impl ValidationBuilder {
     }
 }
 
-impl From<ValidationBuilder> for ValidationResult {
-    fn from(builder: ValidationBuilder) -> Self {
+impl From<ValidationContext> for ValidationResult {
+    fn from(builder: ValidationContext) -> Self {
         builder.inner()
     }
 }
 
+/// The trait that SBOM structs need to implement to validate their content.
 pub trait Validate {
     fn validate(&self, version: SpecVersion) -> ValidationResult;
 }
 
+/// A single validation error with a message, useful to log / display for user.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ValidationError {
     pub message: String,
@@ -99,6 +103,7 @@ impl ValidationError {
     }
 }
 
+/// Implements possible hierarchy of a structured SBOM to collect all [`ValidationError`] in.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ValidationErrorsKind {
     /// Collects all field validation errors in context of a struct


### PR DESCRIPTION
This refactors the code to use a better API to build validation errors hierarchically. It also tries to match the struct names of the cyclonedx-rust-cargo repository to minimize changes.