### PR TITLE
Improve api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,8 +104,16 @@ pub struct Bom {
 impl Validate for Bom {
     fn validate(&self, version: validation::SpecVersion) -> Result<(), ValidationErrors> {
         ValidationContext::new()
-            .add_field("serial_number", self.serial_number.as_ref().map(|sn| validate_string(sn)))
-            .add_struct("meta_data", self.meta_data.as_ref().map(|metadata| metadata.validate(version)))
+            .add_field(
+                "serial_number",
+                self.serial_number.as_ref().map(|sn| validate_string(sn)),
+            )
+            .add_struct(
+                "meta_data",
+                self.meta_data
+                    .as_ref()
+                    .map(|metadata| metadata.validate(version)),
+            )
             .into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,9 +125,7 @@ impl Validate for Bom {
                 self.serial_number.as_ref(),
                 validate_string,
             )
-            .add_struct("meta_data", self.meta_data.as_ref(), |metadata: &_| {
-                metadata.validate(version)
-            })
+            .add_struct_option("meta_data", self.meta_data.as_ref(), version)
             .into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub fn validate_bom(version: SpecVersion, bom: Bom) -> ValidationResult {
 mod tests {
     use crate::{
         validate_bom,
-        validation::{SpecVersion, Validate, ValidationError, ValidationErrorsKind},
+        validation::{SpecVersion, Validate, ValidationErrorsKind},
         Bom, Metadata, Tool, ToolKind,
     };
 
@@ -191,25 +191,17 @@ mod tests {
             Some(
                 &vec![(
                     "meta_data",
-                    ValidationErrorsKind::Struct(
-                        vec![(
-                            "tools",
-                            ValidationErrorsKind::List(
-                                [(
-                                    1,
-                                    vec![(
-                                        "kind",
-                                        ValidationErrorsKind::Enum(ValidationError::new(
-                                            "Tool must not be a hammer"
-                                        ))
-                                    )]
-                                    .into()
-                                )]
-                                .into()
-                            )
-                        )]
-                        .into()
-                    )
+                    ValidationErrorsKind::r#struct(&[(
+                        "tools",
+                        ValidationErrorsKind::list(&[(
+                            1,
+                            vec![(
+                                "kind",
+                                ValidationErrorsKind::r#enum("Tool must not be a hammer")
+                            )]
+                            .into()
+                        )])
+                    )])
                 )]
                 .into()
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,13 @@ pub struct Tool {
 impl Validate for Tool {
     fn validate(&self, _version: validation::SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_field("vendor", self.vendor.as_deref(), validate_vendor)
+            .add_field_option("vendor", self.vendor.as_ref(), |vendor| {
+                validate_vendor(vendor)
+            })
             .add_field("name", &*self.name, validate_string)
-            .add_field("lastname", self.lastname.as_deref(), validate_string)
+            .add_field_option("lastname", self.lastname.as_ref(), |lastname| {
+                validate_string(lastname)
+            })
             .add_enum("kind", &self.kind, validate_toolkind)
             .into()
     }
@@ -86,12 +90,16 @@ impl Validate for Metadata {
 
         match version {
             SpecVersion::V1_4 => {
-                builder =
-                    builder.add_field("timestamp", self.timestamp.as_deref(), validate_string);
+                builder = builder.add_field_option("timestamp", self.timestamp.as_ref(), |t| {
+                    validate_string(&t)
+                });
             }
             _ => {
-                builder =
-                    builder.add_field("timestamp", self.timestamp.as_deref(), validate_timestamp);
+                builder = builder.add_field_option(
+                    "timestamp",
+                    self.timestamp.as_deref(),
+                    validate_timestamp,
+                );
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub fn validate_bom(version: SpecVersion, bom: Bom) -> ValidationResult {
 mod tests {
     use crate::{
         validate_bom,
-        validation::{SpecVersion, Validate, ValidationErrorsKind},
+        validation::{self, list, r#enum, r#struct, SpecVersion, Validate},
         Bom, Metadata, Tool, ToolKind,
     };
 
@@ -186,25 +186,16 @@ mod tests {
         };
 
         let validation_result = bom.validate(SpecVersion::V1_3);
+
         assert_eq!(
             validation_result.errors(),
-            Some(
-                &vec![(
-                    "meta_data",
-                    ValidationErrorsKind::r#struct(&[(
-                        "tools",
-                        ValidationErrorsKind::list(&[(
-                            1,
-                            vec![(
-                                "kind",
-                                ValidationErrorsKind::r#enum("Tool must not be a hammer")
-                            )]
-                            .into()
-                        )])
-                    )])
-                )]
-                .into()
-            )
+            Some(validation::r#struct(
+                "meta_data",
+                validation::list(
+                    "tools",
+                    &[(1, validation::r#enum("kind", "Tool must not be a hammer"))]
+                ),
+            ))
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,9 +114,7 @@ pub fn validate_bom(version: SpecVersion, bom: Bom) -> ValidationResult {
 mod tests {
     use crate::{
         validate_bom,
-        validation::{
-            SpecVersion, Validate, ValidationError, ValidationErrors, ValidationErrorsKind,
-        },
+        validation::{SpecVersion, Validate, ValidationError, ValidationErrorsKind},
         Bom, Metadata, Tool, ToolKind,
     };
 
@@ -190,32 +188,31 @@ mod tests {
         let validation_result = bom.validate(SpecVersion::V1_3);
         assert_eq!(
             validation_result.errors(),
-            Some(&ValidationErrors {
-                inner: [(
-                    "meta_data".to_string(),
-                    ValidationErrorsKind::Struct(ValidationErrors {
-                        inner: [(
-                            "tools".to_string(),
+            Some(
+                &vec![(
+                    "meta_data",
+                    ValidationErrorsKind::Struct(
+                        vec![(
+                            "tools",
                             ValidationErrorsKind::List(
                                 [(
                                     1,
-                                    ValidationErrors {
-                                        inner: [(
-                                            "kind".to_string(),
-                                            ValidationErrorsKind::Enum(ValidationError::new(
-                                                "Tool must not be a hammer"
-                                            ))
-                                        )].into()
-                                    }
+                                    vec![(
+                                        "kind",
+                                        ValidationErrorsKind::Enum(ValidationError::new(
+                                            "Tool must not be a hammer"
+                                        ))
+                                    )]
+                                    .into()
                                 )]
                                 .into()
                             )
                         )]
                         .into()
-                    })
+                    )
                 )]
                 .into()
-            }),
+            )
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 mod validation;
 
+use std::ops::Deref;
+
 use validation::{SpecVersion, Validate, ValidationContext, ValidationError, ValidationResult};
 
 fn validate_timestamp(input: &str) -> Result<(), validation::ValidationError> {
@@ -29,6 +31,23 @@ fn validate_toolkind(kind: &ToolKind) -> Result<(), validation::ValidationError>
     Ok(())
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DateTime(pub(crate) String);
+
+impl From<&str> for DateTime {
+    fn from(value: &str) -> Self {
+        DateTime(value.to_string())
+    }
+}
+
+impl Deref for DateTime {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Debug)]
 pub enum ToolKind {
     Hammer,
@@ -56,7 +75,7 @@ impl Validate for Tool {
 
 #[derive(Debug)]
 pub struct Metadata {
-    pub timestamp: Option<String>,
+    pub timestamp: Option<DateTime>,
     pub tools: Vec<Tool>,
 }
 
@@ -114,8 +133,8 @@ pub fn validate_bom(version: SpecVersion, bom: Bom) -> ValidationResult {
 mod tests {
     use crate::{
         validate_bom,
-        validation::{self, list, r#enum, r#struct, SpecVersion, Validate},
-        Bom, Metadata, Tool, ToolKind,
+        validation::{self, SpecVersion, Validate},
+        Bom, DateTime, Metadata, Tool, ToolKind,
     };
 
     #[test]
@@ -123,7 +142,7 @@ mod tests {
         let bom = Bom {
             serial_number: "1234".to_string(),
             meta_data: Some(Metadata {
-                timestamp: Some(String::from("2024-01-02")),
+                timestamp: Some(DateTime::from("2024-01-02")),
                 tools: vec![Tool {
                     vendor: Some(String::from("Vendor")),
                     name: String::from("dig"),
@@ -141,7 +160,7 @@ mod tests {
         let bom = Bom {
             serial_number: "1234".to_string(),
             meta_data: Some(Metadata {
-                timestamp: Some(String::from("2024-01-02")),
+                timestamp: Some(DateTime::from("2024-01-02")),
                 tools: vec![
                     Tool {
                         vendor: Some(String::from("Vendor")),
@@ -167,7 +186,7 @@ mod tests {
         let bom = Bom {
             serial_number: "1234".to_string(),
             meta_data: Some(Metadata {
-                timestamp: Some(String::from("2024-01-02")),
+                timestamp: Some(DateTime::from("2024-01-02")),
                 tools: vec![
                     Tool {
                         vendor: Some(String::from("Vendor")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 mod validation;
 
-use validation::{SpecVersion, Validate, ValidationContext, ValidationError, ValidationErrors};
+use validation::{SpecVersion, Validate, ValidationContext, ValidationError, ValidationResult};
 
 fn validate_timestamp(input: &str) -> Result<(), validation::ValidationError> {
     if input.contains("a") {
@@ -43,7 +43,7 @@ pub struct Tool {
 }
 
 impl Validate for Tool {
-    fn validate(&self, _version: validation::SpecVersion) -> Result<(), ValidationErrors> {
+    fn validate(&self, _version: validation::SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field(
                 "vendor",
@@ -65,7 +65,7 @@ pub struct Metadata {
 }
 
 impl Validate for Metadata {
-    fn validate(&self, version: SpecVersion) -> Result<(), ValidationErrors> {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let children = self.tools.as_ref().map(|tools| {
             tools
                 .iter()
@@ -102,7 +102,7 @@ pub struct Bom {
 
 /// The implementation should be easy to digest
 impl Validate for Bom {
-    fn validate(&self, version: validation::SpecVersion) -> Result<(), ValidationErrors> {
+    fn validate(&self, version: validation::SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field(
                 "serial_number",
@@ -119,7 +119,7 @@ impl Validate for Bom {
 }
 
 /// Validates the bom according to a given [`SpecVersion`].
-pub fn validate_bom(version: SpecVersion, bom: Bom) -> Result<(), ValidationErrors> {
+pub fn validate_bom(version: SpecVersion, bom: Bom) -> ValidationResult {
     bom.validate(version)
 }
 
@@ -141,7 +141,7 @@ mod tests {
             }),
         };
 
-        assert!(dbg!(validate_bom(SpecVersion::V1_3, bom)).is_ok());
+        assert!(dbg!(validate_bom(SpecVersion::V1_3, bom)).passed());
     }
 
     #[test]
@@ -165,6 +165,6 @@ mod tests {
             }),
         };
 
-        assert!(dbg!(validate_bom(SpecVersion::V1_4, bom)).is_err());
+        assert!(dbg!(validate_bom(SpecVersion::V1_4, bom)).has_errors());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,18 +57,13 @@ impl Validate for Tool {
 #[derive(Debug)]
 pub struct Metadata {
     pub timestamp: Option<String>,
-    pub tools: Option<Vec<Tool>>,
+    pub tools: Vec<Tool>,
 }
 
 impl Validate for Metadata {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut builder =
-            ValidationContext::new().add_list("tools", self.tools.as_deref(), |tools: &[_]| {
-                tools
-                    .into_iter()
-                    .map(|tool| tool.validate(version))
-                    .collect()
-            });
+        let mut builder = ValidationContext::new()
+            .add_list("tools", self.tools.iter(), |tool: &Tool| tool.validate(version));
 
         match version {
             SpecVersion::V1_4 => {
@@ -107,13 +102,6 @@ impl Validate for Bom {
                 metadata.validate(version)
             })
             .into()
-
-        /*
-        ValidationContext::new()
-            .add_field(pass_arg!("serial_number", validate_string))
-            .add_struct(pass_arg!("meta_data", version))
-            .into()
-         */
     }
 }
 
@@ -132,12 +120,12 @@ mod tests {
             serial_number: "1234".to_string(),
             meta_data: Some(Metadata {
                 timestamp: Some(String::from("2024-01-02")),
-                tools: Some(vec![Tool {
+                tools: vec![Tool {
                     vendor: Some(String::from("Vendor")),
                     name: String::from("dig"),
                     lastname: Some(String::from("roe")),
                     kind: ToolKind::ScrewDriver,
-                }]),
+                }],
             }),
         };
 
@@ -150,7 +138,7 @@ mod tests {
             serial_number: "1234".to_string(),
             meta_data: Some(Metadata {
                 timestamp: Some(String::from("2024-01-02")),
-                tools: Some(vec![
+                tools: vec![
                     Tool {
                         vendor: Some(String::from("Vendor")),
                         name: String::from("delv"),
@@ -163,7 +151,7 @@ mod tests {
                         lastname: Some(String::from("roe")),
                         kind: ToolKind::Hammer,
                     },
-                ]),
+                ],
             }),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,8 @@ pub enum ToolKind {
 #[derive(Debug)]
 pub struct Tool {
     pub vendor: Option<String>,
-    pub name: Option<String>,
+    pub name: String,
+    pub lastname: Option<String>,
     pub kind: ToolKind,
 }
 
@@ -46,7 +47,8 @@ impl Validate for Tool {
     fn validate(&self, _version: validation::SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field("vendor", self.vendor.as_deref(), validate_vendor)
-            .add_field("name", self.name.as_deref(), validate_string)
+            .add_field("name", &*self.name, validate_string)
+            .add_field("lastname", self.lastname.as_deref(), validate_string)
             .add_enum("kind", &self.kind, validate_toolkind)
             .into()
     }
@@ -132,7 +134,8 @@ mod tests {
                 timestamp: Some(String::from("2024-01-02")),
                 tools: Some(vec![Tool {
                     vendor: Some(String::from("Vendor")),
-                    name: Some(String::from("dig")),
+                    name: String::from("dig"),
+                    lastname: Some(String::from("roe")),
                     kind: ToolKind::ScrewDriver,
                 }]),
             }),
@@ -150,12 +153,14 @@ mod tests {
                 tools: Some(vec![
                     Tool {
                         vendor: Some(String::from("Vendor")),
-                        name: Some(String::from("delv")),
+                        name: String::from("delv"),
+                        lastname: Some(String::from("hill")),
                         kind: ToolKind::ScrewDriver,
                     },
                     Tool {
                         vendor: Some(String::from("Vendor")),
-                        name: Some(String::from("dig")),
+                        name: String::from("dig"),
+                        lastname: Some(String::from("roe")),
                         kind: ToolKind::Hammer,
                     },
                 ]),

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -66,15 +66,27 @@ impl ValidationContext {
     pub fn add_field<T>(
         self,
         field_name: &str,
-        field: impl Into<Option<T>>,
+        field: T,
         validation: impl FnOnce(T) -> Result<(), ValidationError>,
     ) -> Self {
-        if let Some(Err(error)) = field.into().map(validation) {
+        if let Err(error) = validation(field) {
             Self {
                 state: ValidationErrors::merge_field(self.state, field_name, error),
             }
         } else {
             self
+        }
+    }
+
+    pub fn add_field_option<T>(
+        self,
+        field_name: &str,
+        field: Option<T>,
+        validation: impl FnOnce(T) -> Result<(), ValidationError>,
+    ) -> Self {
+        match field {
+            Some(field) => self.add_field(field_name, field, validation),
+            None => self,
         }
     }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -150,9 +150,9 @@ impl ValidationError {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ValidationErrorsKind {
     /// Collects all field validation errors in context of a struct
-    Struct(Box<ValidationErrors>),
+    Struct(ValidationErrors),
     /// Collects all child elements in context of a list, e.g. `Vec`
-    List(BTreeMap<usize, Box<ValidationErrors>>),
+    List(BTreeMap<usize, ValidationErrors>),
     /// Contains the list of validation errors for a single field, e.g. struct field.
     Field(Vec<ValidationError>),
     /// Represents a single error for an Enum variant.
@@ -204,7 +204,7 @@ impl ValidationErrors {
         let mut errors: ValidationErrors = parent.into();
         errors.add_nested(
             struct_name,
-            ValidationErrorsKind::Struct(Box::new(validation_errors)),
+            ValidationErrorsKind::Struct(validation_errors),
         );
         ValidationResult::Error(errors)
     }
@@ -219,7 +219,7 @@ impl ValidationErrors {
             .enumerate()
             .filter_map(|(index, result)| match result {
                 ValidationResult::Passed => None,
-                ValidationResult::Error(errors) => Some((index, Box::new(errors))),
+                ValidationResult::Error(errors) => Some((index, errors)),
             })
             .collect::<BTreeMap<_, _>>();
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -60,7 +60,17 @@ impl ValidationContext {
         }
     }
 
-    pub fn add_field(self, field_name: &str, error: Option<Result<(), ValidationError>>) -> Self {
+    pub fn add_field<F, T, Input>(self, field_name: &str, field: Input, function: F) -> Self
+    where
+        F: FnOnce(T) -> Result<(), ValidationError>,
+        Input: Into<Option<T>>,
+    {
+        let input: Option<_> = field.into();
+        let error = match input {
+            Some(input) => Some(function(input)),
+            None => None,
+        };
+
         if let Some(Err(error)) = error {
             Self {
                 state: ValidationErrors::merge_field(self.state, field_name, error),

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -90,11 +90,11 @@ impl ValidationContext {
         }
     }
 
-    pub fn add_list<T, L: IntoIterator<Item = T>>(
+    pub fn add_list<T>(
         self,
         list_name: &str,
-        list: impl Into<Option<L>>,
-        validation: impl Fn(L) -> Vec<ValidationResult>,
+        list: impl Into<Option<T>>,
+        validation: impl Fn(T) -> Vec<ValidationResult>,
     ) -> Self {
         if let Some(children) = list.into().map(validation) {
             Self {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -10,7 +10,7 @@ pub enum SpecVersion {
 }
 
 /// Contains all collected validation errors.
-#[derive(Debug, Clone,)]
+#[derive(Debug, Clone)]
 pub enum ValidationResult {
     Passed,
     Error(ValidationErrors),
@@ -164,6 +164,17 @@ pub enum ValidationErrorsKind {
 pub struct ValidationErrors {
     /// Maps a name to a set of context errors.
     pub(crate) inner: IndexMap<String, ValidationErrorsKind>,
+}
+
+impl From<Vec<(&str, ValidationErrorsKind)>> for ValidationErrors {
+    fn from(errors: Vec<(&str, ValidationErrorsKind)>) -> Self {
+        ValidationErrors {
+            inner: errors
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value.clone()))
+                .collect::<IndexMap<_, _>>(),
+        }
+    }
 }
 
 impl ValidationErrors {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -166,6 +166,32 @@ pub struct ValidationErrors {
     pub(crate) inner: IndexMap<String, ValidationErrorsKind>,
 }
 
+#[allow(dead_code)]
+impl ValidationErrorsKind {
+    pub(crate) fn r#enum(error: &str) -> Self {
+        Self::Enum(ValidationError::new(error))
+    }
+
+    pub(crate) fn list(errors: &[(usize, ValidationErrors)]) -> Self {
+        let errors = errors
+            .into_iter()
+            .map(|(index, value)| (*index, value.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        Self::List(errors)
+    }
+
+    pub(crate) fn r#struct(errors: &[(&str, ValidationErrorsKind)]) -> Self {
+        let errors = errors
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value.clone()))
+            .collect::<IndexMap<_, _>>();
+
+        Self::Struct(ValidationErrors { inner: errors })
+    }
+}
+
+/// TODO remove again
 impl From<Vec<(&str, ValidationErrorsKind)>> for ValidationErrors {
     fn from(errors: Vec<(&str, ValidationErrorsKind)>) -> Self {
         ValidationErrors {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -72,15 +72,11 @@ impl ValidationContext {
             self
         }
     }
-
-    pub fn inner(&self) -> ValidationResult {
-        self.state.clone()
-    }
 }
 
 impl From<ValidationContext> for ValidationResult {
     fn from(builder: ValidationContext) -> Self {
-        builder.inner()
+        builder.state
     }
 }
 


### PR DESCRIPTION
This refactor the validation logic to provide a more efficient API.

* add enum type `ValidationResult` to collect all validation errors
* change `std::Result<(), ValidationErrors>` to `ValidationResult`, to avoid situation to return with early `Err` using `?` operator
* adjust argument to `add_field` method to allow either `T` or `Option<&T>`